### PR TITLE
[FEAT] 사용자 이름 입력 페이지 구현 #5

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -5,10 +5,10 @@ export const Header = () => {
   const navigate = useNavigate();
 
   return (
-    <header role='banner'>
+    <header role='banner' className='py-4'>
       <button
         onClick={() => navigate(-1)}
-        className='flex items-center rounded-lg py-4 transition-colors hover:bg-gray-800'
+        className='flex items-center rounded-lg transition-colors hover:bg-gray-800'
         aria-label='이전으로 돌아가기'
       >
         <img src={backIcon} alt='' className='h-5 w-5' aria-hidden='true' />

--- a/src/components/layout/HeaderLayout.tsx
+++ b/src/components/layout/HeaderLayout.tsx
@@ -3,9 +3,11 @@ import { Header } from "../common/Header";
 
 export const HeaderLayout = (): JSX.Element => {
   return (
-    <div className='mx-auto h-dvh max-w-2xl bg-[#121212] px-4 text-white'>
+    <main className='mx-auto flex h-dvh max-w-2xl flex-col bg-[#121212] px-4 text-white'>
       <Header />
-      <Outlet />
-    </div>
+      <section className='flex-1'>
+        <Outlet />
+      </section>
+    </main>
   );
 };

--- a/src/constants/validation.ts
+++ b/src/constants/validation.ts
@@ -1,0 +1,18 @@
+export const NAME_VALIDATION: ValidationRules = {
+  maxLength: 10,
+  rules: {
+    noEmoji: true,
+    onlyKoreanAndEnglish: true,
+  },
+  patterns: {
+    emoji: /[\u{1F300}-\u{1F9FF}]/u,
+    validChars: /^[가-힣a-zA-Z0-9]+$/,
+  },
+  messages: {
+    emoji: "이모지는 사용할 수 없어요.",
+    invalidChars: "한글, 영문, 숫자만 사용할 수 있어요",
+    empty: "이름을 입력해 주세요.",
+    length: "10글자 이하로 입력해 주세요.",
+    space: "공백은 사용할 수 없어요.",
+  },
+};

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -27,13 +27,13 @@ export default function HomePage() {
         <p className='break-all text-center text-xl'>
           특별했던 그 영화,
           <br aria-hidden='true' />
-          <span className='text-emerald-500'>모티</span>와 함께 나누어 보세요
+          <span className='text-emerald-400'>모티</span>와 함께 나누어 보세요
         </p>
       </div>
 
       <button
         onClick={() => navigate("/user")}
-        className='h-14 w-72 rounded bg-emerald-500 px-6 py-4 text-center font-medium transition-colors hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2'
+        className='h-14 w-72 rounded-xl bg-emerald-400 px-6 py-4 text-center font-medium transition-colors hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2'
         aria-label='영화 선택 페이지로 이동하기'
       >
         영화 모티하기

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -1,42 +1,72 @@
-import { useState } from "react";
 import { useNavigate } from "react-router";
+import { useState } from "react";
+import { validateName } from "../../utils/validation";
 
 export default function UserPage() {
   const navigate = useNavigate();
   const [name, setName] = useState("");
+  const [error, setError] = useState("");
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+    setError("");
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const { isValid, message } = validateName(name);
+    if (!isValid) {
+      setError(message || "입력이 올바르지 않습니다");
+      return;
+    }
+
     navigate(`/search?username=${encodeURIComponent(name)}`);
   };
 
   return (
-    <>
+    <div className='flex h-full flex-col py-16'>
       <h1 className='text-center text-3xl leading-loose'>
-        주연은 바로 당신!
+        크레딧의 첫 장면을 장식할
         <br />
-        <span className='text-emerald-400'>이름</span>을 알려주세요
+        당신의 <span className='text-emerald-400'>이름</span>을 알려주세요
       </h1>
-      <form onSubmit={handleSubmit}>
+
+      <form
+        onSubmit={handleSubmit}
+        className='flex flex-1 flex-col items-center justify-between pt-8'
+      >
         <div role='group' aria-labelledby='name-label'>
           <label id='name-label' htmlFor='name-input' className='sr-only'>
-            이름
+            이름 <span aria-label='필수 입력'>*</span>
           </label>
           <input
             id='name-input'
             type='text'
             value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder='이름을 입력해 주세요'
-            className='text-black'
+            onChange={handleNameChange}
+            placeholder='이름을 입력해 주세요 *'
+            className='h-12 w-72 border-b-2 border-emerald-400 bg-transparent text-xl text-white focus:outline-none'
             aria-required='true'
-            autoComplete='name'
+            aria-invalid={!!error}
+            aria-describedby={error ? "name-error" : undefined}
           />
+          {error && (
+            <div
+              className='pt-2 text-sm text-red-400'
+              id='name-error'
+              role='alert'
+            >
+              {error}
+            </div>
+          )}
         </div>
-        <button type='submit' aria-label='다음 페이지로 이동'>
-          다음
+        <button
+          type='submit'
+          className='h-14 w-72 rounded-xl bg-emerald-400 px-6 py-4 text-center font-medium transition-colors hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-600 focus:ring-offset-2'
+        >
+          다음으로
         </button>
       </form>
-    </>
+    </div>
   );
 }

--- a/src/types/validation.d.ts
+++ b/src/types/validation.d.ts
@@ -1,0 +1,22 @@
+declare type ValidationResult = {
+  isValid: boolean;
+  message?: string;
+};
+
+declare type ValidationRulesKey = "noEmoji" | "onlyKoreanAndEnglish";
+
+declare type ValidationMessageKey =
+  | "emoji"
+  | "invalidChars"
+  | "space"
+  | "empty"
+  | "length";
+
+declare type ValidationPatternKey = "emoji" | "validChars";
+
+declare type ValidationRules = {
+  maxLength: number;
+  patterns: Record<ValidationPatternKey, RegExp>;
+  messages: Record<ValidationMessageKey, string>;
+  rules: Record<ValidationRulesKey, boolean>;
+};

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,48 @@
+import { NAME_VALIDATION } from "./../constants/validation";
+
+const hasEmoji = (text: string): boolean => {
+  return NAME_VALIDATION.patterns.emoji.test(text);
+};
+
+const hasValidChars = (text: string): boolean => {
+  return NAME_VALIDATION.patterns.validChars.test(text);
+};
+
+export const validateName = (name: string): ValidationResult => {
+  if (!name) {
+    return {
+      isValid: false,
+      message: NAME_VALIDATION.messages.empty,
+    };
+  }
+
+  if (name !== name.trim()) {
+    return {
+      isValid: false,
+      message: NAME_VALIDATION.messages.space,
+    };
+  }
+
+  if (hasEmoji(name)) {
+    return {
+      isValid: false,
+      message: NAME_VALIDATION.messages.emoji,
+    };
+  }
+
+  if (!hasValidChars(name)) {
+    return {
+      isValid: false,
+      message: NAME_VALIDATION.messages.invalidChars,
+    };
+  }
+
+  if (name.length > NAME_VALIDATION.maxLength) {
+    return {
+      isValid: false,
+      message: NAME_VALIDATION.messages.length,
+    };
+  }
+
+  return { isValid: true };
+};


### PR DESCRIPTION
## 📝 설명
본 PR에서는 사용자 이름 입력 페이지 컴포넌트 및 로직 구현을 진행했습니다.

## ✨ 주요 변경 사항
### 유효성 검사(validation)
- 유효성 검사 기능 구현을 위해 유틸리티 함수, 타입, 상수 파일을 분리했습니다.
- 타입의 경우 확장성을 고려해 Record 타입을 사용했습니다.
- 사용자의 입력에 대해 유효성 검사를 진행합니다:
  - 이모지 포함 여부
  - 10글자 초과 여부
  - 공백, 빈 값 여부

### 사용자 이름 입력 페이지(UserPage)
- 사용자의 이름을 입력받아, search params에 추가합니다.
- 추가된 search params는 SearchPage 컴포넌트에서 사용할 수 있습니다.

## 📸 스크린샷
<div align="center">
  <img src="https://github.com/user-attachments/assets/9be176af-1206-4406-a1b4-8f5ee7a05334" width="393" alt="userpage" />
</div>


## ✅ 체크리스트
- [x] 브랜치가 올바른지 확인
- [x] 불필요한 console.log 제거
- [x] 불필요한 주석 제거